### PR TITLE
Face match parallel

### DIFF
--- a/src/face-detection-recognition/face_detection_recognition/database_functions.py
+++ b/src/face-detection-recognition/face_detection_recognition/database_functions.py
@@ -78,7 +78,6 @@ class Vector_Database:
         metadatas = [{"image_path": d["image_path"]} for d in data]
 
         collection = self.get_collection(collection)
-
         collection.add(
             embeddings=list(df["embedding"]),
             metadatas=metadatas,
@@ -139,11 +138,8 @@ class Vector_Database:
     def query_bulk(self, collection, data, n_results, threshold, similarity_filter):
         vectors_per_query = np.array(list(map(lambda query: len(query), data)))
         vectors_per_query_idx = np.cumsum(vectors_per_query)[:-1]
-
-        query_vectors = [face["embedding"] for query in data for face in query]
-
+        query_vectors = [face["embedding"] for face in data]
         collection = self.get_collection(collection)
-
         result = collection.query(
             query_embeddings=query_vectors,
             n_results=n_results,

--- a/src/face-detection-recognition/face_detection_recognition/database_functions.py
+++ b/src/face-detection-recognition/face_detection_recognition/database_functions.py
@@ -34,7 +34,7 @@ class Vector_Database:
         if testing == "true":
             self.client = chromadb.EphemeralClient()
         else:
-            self.client = chromadb.PersistentClient(path="../resources/data")
+            self.client = chromadb.PersistentClient(path=os.path.abspath(os.path.join(os.getcwd(), "src", "face-detection-recognition", "resources","data")))
 
     def create_full_collection_name(self, base_name, detector, model, isEnsemble):
         return f"{base_name}_{detector.lower()[0:2]}{model.lower()[0:2]}{self.ensemble_indicator if isEnsemble else self.single_indicator}"

--- a/src/face-detection-recognition/face_detection_recognition/database_functions.py
+++ b/src/face-detection-recognition/face_detection_recognition/database_functions.py
@@ -34,7 +34,17 @@ class Vector_Database:
         if testing == "true":
             self.client = chromadb.EphemeralClient()
         else:
-            self.client = chromadb.PersistentClient(path=os.path.abspath(os.path.join(os.getcwd(), "src", "face-detection-recognition", "resources","data")))
+            self.client = chromadb.PersistentClient(
+                path=os.path.abspath(
+                    os.path.join(
+                        os.getcwd(),
+                        "src",
+                        "face-detection-recognition",
+                        "resources",
+                        "data",
+                    )
+                )
+            )
 
     def create_full_collection_name(self, base_name, detector, model, isEnsemble):
         return f"{base_name}_{detector.lower()[0:2]}{model.lower()[0:2]}{self.ensemble_indicator if isEnsemble else self.single_indicator}"

--- a/src/face-detection-recognition/face_detection_recognition/database_functions.py
+++ b/src/face-detection-recognition/face_detection_recognition/database_functions.py
@@ -138,7 +138,7 @@ class Vector_Database:
     def query_bulk(self, collection, data, n_results, threshold, similarity_filter):
         vectors_per_query = np.array(list(map(lambda query: len(query), data)))
         vectors_per_query_idx = np.cumsum(vectors_per_query)[:-1]
-        query_vectors = [face["embedding"] for face in data]
+        query_vectors = [face["embedding"] for query in data for face in query]
         collection = self.get_collection(collection)
         result = collection.query(
             query_embeddings=query_vectors,

--- a/src/face-detection-recognition/face_detection_recognition/face_match_server.py
+++ b/src/face-detection-recognition/face_detection_recognition/face_match_server.py
@@ -283,11 +283,16 @@ def find_face_bulk_endpoint(
     # Check CUDNN compatability
     check_cuDNN_version()
 
+    full_collection_name = DB.create_full_collection_name(parameters["collection_name"],
+                                                          config["detector_backend"], 
+                                                          config["model_name"],
+                                                          False)
+
     # Call model function to find matches
     status, results = face_match_model.find_face_bulk(
         inputs["query_directory"].path,
         parameters["similarity_threshold"],
-        parameters["collection_name"],
+        full_collection_name,
     )
     log_info(status)
 
@@ -515,8 +520,7 @@ def bulk_upload_endpoint(
         base_collection_name = parameters["dropdown_collection_name"]
     else:
         base_collection_name = parameters["collection_name"]
-    # log_info("ERROR FOLLOWING THIS LINE **************************")
-    # log_info(new_collection_name)
+
     # Check CUDNN compatability
     check_cuDNN_version()
     # Get list of directory paths from input

--- a/src/face-detection-recognition/face_detection_recognition/face_representation.py
+++ b/src/face-detection-recognition/face_detection_recognition/face_representation.py
@@ -34,6 +34,7 @@ def detect_faces_and_get_embeddings(
     input_size=(640, 640),
     visualize=False,
     height_factor=1.5,
+    separate_detections=False, # boolean whether or not to separate detections per img in output,
 ):
     script_dir = os.path.dirname(os.path.abspath(__file__))
     models_dir = os.path.join(script_dir, "models")
@@ -46,7 +47,7 @@ def detect_faces_and_get_embeddings(
 
     if visualize:
         os.makedirs("debug_detections", exist_ok=True)
-
+    
     try:
         if detector_onnx_path is None or not os.path.isfile(detector_onnx_path):
             logger.error(f"ONNX model not found: {detector_onnx_path}")
@@ -74,7 +75,7 @@ def detect_faces_and_get_embeddings(
             
             original_size = (img.shape[1], img.shape[0])
             original_sizes.append(original_size)
-        
+
         all_boxes, all_scores, all_landmarks = [],[],[]
         if detector_backend == "retinaface":
             try:
@@ -89,7 +90,6 @@ def detect_faces_and_get_embeddings(
                     all_boxes.append(boxes)
                     all_scores.append(scores)
                     all_landmarks.append(landmarks)
-
                 if model_name == "Facenet512":
                     # Facenet512 pipeline
                     face_embeddings = process_retinaface_detections_for_facenet512(
@@ -102,6 +102,7 @@ def detect_faces_and_get_embeddings(
                         all_boxes,
                         all_scores,
                         all_landmarks,
+                        separate_detections
                     )
                 elif model_name == "ArcFace":
                     # ArcFace-optimized pipeline
@@ -116,8 +117,8 @@ def detect_faces_and_get_embeddings(
                         all_boxes,
                         all_scores,
                         all_landmarks,
+                        separate_detections
                     )
-
 
                 if len(face_embeddings) > 0:
                     return True, face_embeddings
@@ -218,6 +219,7 @@ def detect_faces_and_get_embeddings(
                 model_name,
                 face_confidence_threshold,
                 detector_backend,
+                separate_detections=separate_detections
             )
 
             if len(face_embeddings) > 0:

--- a/src/face-detection-recognition/face_detection_recognition/face_representation.py
+++ b/src/face-detection-recognition/face_detection_recognition/face_representation.py
@@ -10,7 +10,6 @@ from face_detection_recognition.utils.retinaface_utils import (
     process_retinaface_detections_for_facenet512,
     process_retinaface_detections_for_arcface,
 )
-from face_detection_recognition.hash import sha256_image
 
 import os
 import cv2
@@ -25,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 def detect_faces_and_get_embeddings(
-    image_path,
+    image_paths,
     model_name="ArcFace",
     detector_backend="retinaface",
     detector_onnx_path=None,
@@ -45,11 +44,6 @@ def detect_faces_and_get_embeddings(
     elif detector_backend == "retinaface":
         detector_onnx_path = os.path.join(models_dir, "retinaface-resnet50.onnx")
 
-    if model_name == "ArcFace":
-        model_onnx_path = os.path.join(models_dir, "arcface_model_new.onnx")
-    elif model_name == "Facenet512":
-        model_onnx_path = os.path.join(models_dir, "facenet512_model.onnx")
-
     if visualize:
         os.makedirs("debug_detections", exist_ok=True)
 
@@ -57,72 +51,73 @@ def detect_faces_and_get_embeddings(
         if detector_onnx_path is None or not os.path.isfile(detector_onnx_path):
             logger.error(f"ONNX model not found: {detector_onnx_path}")
             return False, []
-
-        # Load image
-        if isinstance(image_path, str):
-            img = cv2.imread(image_path)
-            if img is None:
-                logger.error(f"Failed to load image: {image_path}")
-                return False, []
-            img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-            path_str = image_path
-        else:
-            img = image_path
-            if len(img.shape) == 3 and img.shape[2] == 3:
-                if img.dtype != np.uint8:
-                    img = img.astype(np.uint8)
-            path_str = "array_input"
+        
+        imgs = []
+        original_sizes = []
 
         target_size = get_target_size(model_name)
-        original_size = (img.shape[1], img.shape[0])
+        
+        for image_path in image_paths:
+            img = cv2.imread(image_path)
+            if img is None:
+                img_raw = cv2.imread(image_path, cv2.IMREAD_COLOR)
+                if img_raw is None:
+                    logger.error(f"Failed to load image: {image_path}")
+                    img = np.zeros((480, 640, 3),dtype=np.uint8)
+                else:
+                    img = cv2.cvtColor(img_raw, cv2.COLOR_BGR2RGB)
+            else:
+                img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
 
+            imgs.append(img)
+
+            
+            original_size = (img.shape[1], img.shape[0])
+            original_sizes.append(original_size)
+        
+        all_boxes, all_scores, all_landmarks = [],[],[]
         if detector_backend == "retinaface":
             try:
-                boxes, scores, landmarks = detect_with_retinaface(
-                    image_path=image_path if isinstance(image_path, str) else None,
-                    img_rgb=img if not isinstance(image_path, str) else None,
-                    model_path=detector_onnx_path,
-                    confidence_threshold=0.02,
-                    visualize=visualize,
-                )
+                for img_rgb,image_path in zip(imgs, image_paths):
+                    boxes, scores, landmarks = detect_with_retinaface(
+                        image_path=image_path, # if isinstance(image_path, str) else None,
+                        img_rgb=img_rgb, # if not isinstance(image_path, str) else None,
+                        model_path=detector_onnx_path,
+                        confidence_threshold=0.02,
+                        visualize=visualize,
+                    )
+                    all_boxes.append(boxes)
+                    all_scores.append(scores)
+                    all_landmarks.append(landmarks)
 
                 if model_name == "Facenet512":
                     # Facenet512 pipeline
                     face_embeddings = process_retinaface_detections_for_facenet512(
-                        img,
+                        imgs,
                         align,
                         target_size,
-                        normalization,
                         visualize,
-                        image_path,
+                        image_paths,
                         model_name,
-                        model_onnx_path,
-                        path_str,
-                        boxes,
-                        scores,
-                        landmarks,
+                        all_boxes,
+                        all_scores,
+                        all_landmarks,
                     )
                 elif model_name == "ArcFace":
                     # ArcFace-optimized pipeline
                     face_embeddings = process_retinaface_detections_for_arcface(
-                        img,
+                        imgs,
                         align,
                         target_size,
                         normalization,
                         visualize,
-                        image_path,
+                        image_paths,
                         model_name,
-                        model_onnx_path,
-                        path_str,
-                        boxes,
-                        scores,
-                        landmarks,
+                        all_boxes,
+                        all_scores,
+                        all_landmarks,
                     )
 
-                for result in face_embeddings:
-                    image = sha256_image(result["image_path"], result["bbox"])
-                    result["sha256_image"] = image
-                    result["model_name"] = model_name
 
                 if len(face_embeddings) > 0:
                     return True, face_embeddings
@@ -163,67 +158,67 @@ def detect_faces_and_get_embeddings(
         letterbox_info = None
         if detector_backend == "yolov8":
 
-            scale = min(
-                input_size[0] / original_size[0], input_size[1] / original_size[1]
-            )
-            new_w = int(original_size[0] * scale)
-            new_h = int(original_size[1] * scale)
-            pad_w = (input_size[0] - new_w) // 2
-            pad_h = (input_size[1] - new_h) // 2
+            all_boxes, all_scores, all_landmarks = [],[],[]
+            for img, original_size in zip(imgs, original_sizes):
 
-            letterbox_info = {
-                "scale": scale,
-                "pad_w": pad_w,
-                "pad_h": pad_h,
-                "orig_size": original_size,
-            }
-
-            img_resized = cv2.resize(img, (new_w, new_h))
-            letterbox_img = np.zeros((input_size[1], input_size[0], 3), dtype=np.uint8)
-            letterbox_img[pad_h : pad_h + new_h, pad_w : pad_w + new_w, :] = img_resized
-            img_norm = letterbox_img.astype(np.float32) / 255.0
-            img_input = np.expand_dims(img_norm.transpose(2, 0, 1), axis=0)
-
-            outputs = detector_session.run(None, {input_name: img_input})
-
-            if model_name == "ArcFace":
-                height_factor = 1.3
-
-            boxes, scores, landmarks = process_yolov8_output(
-                outputs, letterbox_info, height_factor
-            )
-
-            # Visualize detections
-            if visualize and isinstance(image_path, str) and len(boxes) > 0:
-                debug_dir = "debug_detections"
-                os.makedirs(debug_dir, exist_ok=True)
-                vis_path = os.path.join(
-                    debug_dir, os.path.basename(image_path) + "_detect.jpg"
+                scale = min(
+                    input_size[0] / original_size[0], input_size[1] / original_size[1]
                 )
-                visualize_detections(img, boxes, scores, landmarks, save_path=vis_path)
+                new_w = int(original_size[0] * scale)
+                new_h = int(original_size[1] * scale)
+                pad_w = (input_size[0] - new_w) // 2
+                pad_h = (input_size[1] - new_h) // 2
+
+                letterbox_info = {
+                    "scale": scale,
+                    "pad_w": pad_w,
+                    "pad_h": pad_h,
+                    "orig_size": original_size,
+                }
+
+                img_resized = cv2.resize(img, (new_w, new_h))
+                letterbox_img = np.zeros((input_size[1], input_size[0], 3), dtype=np.uint8)
+                letterbox_img[pad_h : pad_h + new_h, pad_w : pad_w + new_w, :] = img_resized
+                img_norm = letterbox_img.astype(np.float32) / 255.0
+                img_input = np.expand_dims(img_norm.transpose(2, 0, 1), axis=0)
+
+                outputs = detector_session.run(None, {input_name: img_input})
+
+                if model_name == "ArcFace":
+                    height_factor = 1.3
+
+                boxes, scores, landmarks = process_yolov8_output(
+                    outputs, letterbox_info, height_factor
+                )
+
+                all_boxes.append(boxes)
+                all_scores.append(scores)
+                all_landmarks.append(landmarks)
+
+                # Visualize detections
+                if visualize and isinstance(image_path, str) and len(boxes) > 0:
+                    debug_dir = "debug_detections"
+                    os.makedirs(debug_dir, exist_ok=True)
+                    vis_path = os.path.join(
+                        debug_dir, os.path.basename(image_path) + "_detect.jpg"
+                    )
+                    visualize_detections(img, boxes, scores, landmarks, save_path=vis_path)
 
             # Process detections and get embeddings
             face_embeddings = process_yolo_detections(
-                img,
-                boxes,
-                scores,
-                landmarks,
+                imgs,
+                all_boxes,
+                all_scores,
+                all_landmarks,
                 align,
                 target_size,
                 normalization,
                 visualize,
-                image_path,
+                image_paths,
                 model_name,
-                model_onnx_path,
-                path_str,
                 face_confidence_threshold,
                 detector_backend,
             )
-
-            for result in face_embeddings:
-                image = sha256_image(result["image_path"], result["bbox"])
-                result["sha256_image"] = image
-                result["model_name"] = model_name
 
             if len(face_embeddings) > 0:
                 return True, face_embeddings

--- a/src/face-detection-recognition/face_detection_recognition/face_representation.py
+++ b/src/face-detection-recognition/face_detection_recognition/face_representation.py
@@ -34,7 +34,7 @@ def detect_faces_and_get_embeddings(
     input_size=(640, 640),
     visualize=False,
     height_factor=1.5,
-    separate_detections=False, # boolean whether or not to separate detections per img in output,
+    separate_detections=False,  # boolean whether or not to separate detections per img in output,
 ):
     script_dir = os.path.dirname(os.path.abspath(__file__))
     models_dir = os.path.join(script_dir, "models")
@@ -47,24 +47,24 @@ def detect_faces_and_get_embeddings(
 
     if visualize:
         os.makedirs("debug_detections", exist_ok=True)
-    
+
     try:
         if detector_onnx_path is None or not os.path.isfile(detector_onnx_path):
             logger.error(f"ONNX model not found: {detector_onnx_path}")
             return False, []
-        
+
         imgs = []
         original_sizes = []
 
         target_size = get_target_size(model_name)
-        
+
         for image_path in image_paths:
             img = cv2.imread(image_path)
             if img is None:
                 img_raw = cv2.imread(image_path, cv2.IMREAD_COLOR)
                 if img_raw is None:
                     logger.error(f"Failed to load image: {image_path}")
-                    img = np.zeros((480, 640, 3),dtype=np.uint8)
+                    img = np.zeros((480, 640, 3), dtype=np.uint8)
                 else:
                     img = cv2.cvtColor(img_raw, cv2.COLOR_BGR2RGB)
             else:
@@ -72,17 +72,16 @@ def detect_faces_and_get_embeddings(
 
             imgs.append(img)
 
-            
             original_size = (img.shape[1], img.shape[0])
             original_sizes.append(original_size)
 
-        all_boxes, all_scores, all_landmarks = [],[],[]
+        all_boxes, all_scores, all_landmarks = [], [], []
         if detector_backend == "retinaface":
             try:
-                for img_rgb,image_path in zip(imgs, image_paths):
+                for img_rgb, image_path in zip(imgs, image_paths):
                     boxes, scores, landmarks = detect_with_retinaface(
-                        image_path=image_path, # if isinstance(image_path, str) else None,
-                        img_rgb=img_rgb, # if not isinstance(image_path, str) else None,
+                        image_path=image_path,  # if isinstance(image_path, str) else None,
+                        img_rgb=img_rgb,  # if not isinstance(image_path, str) else None,
                         model_path=detector_onnx_path,
                         confidence_threshold=0.02,
                         visualize=visualize,
@@ -102,7 +101,7 @@ def detect_faces_and_get_embeddings(
                         all_boxes,
                         all_scores,
                         all_landmarks,
-                        separate_detections
+                        separate_detections,
                     )
                 elif model_name == "ArcFace":
                     # ArcFace-optimized pipeline
@@ -117,7 +116,7 @@ def detect_faces_and_get_embeddings(
                         all_boxes,
                         all_scores,
                         all_landmarks,
-                        separate_detections
+                        separate_detections,
                     )
 
                 if len(face_embeddings) > 0:
@@ -159,7 +158,7 @@ def detect_faces_and_get_embeddings(
         letterbox_info = None
         if detector_backend == "yolov8":
 
-            all_boxes, all_scores, all_landmarks = [],[],[]
+            all_boxes, all_scores, all_landmarks = [], [], []
             for img, original_size in zip(imgs, original_sizes):
 
                 scale = min(
@@ -178,8 +177,12 @@ def detect_faces_and_get_embeddings(
                 }
 
                 img_resized = cv2.resize(img, (new_w, new_h))
-                letterbox_img = np.zeros((input_size[1], input_size[0], 3), dtype=np.uint8)
-                letterbox_img[pad_h : pad_h + new_h, pad_w : pad_w + new_w, :] = img_resized
+                letterbox_img = np.zeros(
+                    (input_size[1], input_size[0], 3), dtype=np.uint8
+                )
+                letterbox_img[pad_h : pad_h + new_h, pad_w : pad_w + new_w, :] = (
+                    img_resized
+                )
                 img_norm = letterbox_img.astype(np.float32) / 255.0
                 img_input = np.expand_dims(img_norm.transpose(2, 0, 1), axis=0)
 
@@ -203,7 +206,9 @@ def detect_faces_and_get_embeddings(
                     vis_path = os.path.join(
                         debug_dir, os.path.basename(image_path) + "_detect.jpg"
                     )
-                    visualize_detections(img, boxes, scores, landmarks, save_path=vis_path)
+                    visualize_detections(
+                        img, boxes, scores, landmarks, save_path=vis_path
+                    )
 
             # Process detections and get embeddings
             face_embeddings = process_yolo_detections(
@@ -219,7 +224,7 @@ def detect_faces_and_get_embeddings(
                 model_name,
                 face_confidence_threshold,
                 detector_backend,
-                separate_detections=separate_detections
+                separate_detections=separate_detections,
             )
 
             if len(face_embeddings) > 0:

--- a/src/face-detection-recognition/face_detection_recognition/interface.py
+++ b/src/face-detection-recognition/face_detection_recognition/interface.py
@@ -16,6 +16,7 @@ class FaceMatchModel:
     # Function that takes in path to directory of images to upload to database and returns a success or failure message.
     def bulk_upload(self, image_directory_path, collection_name=None):
         try:
+            upload_batch_size = 100
             # Get database from config file.
             if collection_name is None:
                 config_path = get_config_path("db_config.json")
@@ -31,62 +32,60 @@ class FaceMatchModel:
             detector_backend = config["detector_backend"]
             face_confidence_threshold = config["face_confidence_threshold"]
 
-            # Call face_recognition function for each image file.
-            total_files_read = 0
-            total_files_uploaded = 0
-            embedding_outputs = []
-
             # Make image_directory_path absolute path since it is stored in database
             image_directory_path = os.path.abspath(image_directory_path)
+
+            img_paths = []
+
             for root, dirs, files in os.walk(image_directory_path):
                 files.sort()
                 for filename in files:
-                    image_path = os.path.join(root, filename)
-                    if filename.lower().endswith(
-                        (".png", ".jpg", ".jpeg", ".gif", ".bmp")
-                    ):
-                        # Count the totalnumber of files read
-                        total_files_read += 1
+                    if filename.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp")):
+                        img_paths.append(os.path.join(image_directory_path, filename))
 
-                        # Get status and face_embeddings for the image
-                        status, value = detect_faces_and_get_embeddings(
-                            image_path,
-                            model_name,
-                            detector_backend,
-                            face_confidence_threshold,
-                        )
-                        if status:
-                            total_files_uploaded += 1
-                            embedding_outputs.extend(value)
+            end_idx = 0
 
-                    # Log info for every 100 files that are successfully converted.
-                    if total_files_uploaded % 100 == 0 and total_files_uploaded != 0:
-                        log_info(
-                            "Successfully converted file "
-                            + str(total_files_uploaded)
-                            + " / "
-                            + str(total_files_read)
-                            + " to "
-                            "embeddings"
-                        )
+            total_files_read = len(img_paths)
+            total_files_uploaded = 0
 
-                    # Upload every 1000 files into database for more efficiency and security.
-                    if total_files_uploaded % 1000 == 0 and total_files_uploaded != 0:
-                        self.DB.upload_embedding_to_database(
-                            embedding_outputs, collection_name
-                        )
-                        embedding_outputs = []
-                        log_info(
-                            "Successfully uploaded "
-                            + str(total_files_uploaded)
-                            + " / "
-                            + str(total_files_read)
-                            + " files to "
-                            + collection_name
-                        )
+            for batch in range(len(img_paths) // upload_batch_size):
+                start_idx = batch * upload_batch_size
+                end_idx = start_idx + upload_batch_size
+                status, embedding_outputs = detect_faces_and_get_embeddings(
+                    img_paths[start_idx:end_idx],
+                    model_name,
+                    detector_backend,
+                    face_confidence_threshold
+                )
 
-            if len(embedding_outputs) != 0:
-                self.DB.upload_embedding_to_database(embedding_outputs, collection_name)
+                total_files_uploaded += upload_batch_size
+
+                self.DB.upload_embedding_to_database(
+                        embedding_outputs,
+                        collection_name,
+                )
+
+                log_info(
+                    "Successfully uploaded "
+                    + str(total_files_uploaded)
+                    + " / "
+                    + str(total_files_read)
+                    + " files to "
+                    + collection_name
+                )
+            if (len(img_paths) % upload_batch_size) != 0:
+                status, embedding_outputs = detect_faces_and_get_embeddings(
+                    img_paths[end_idx:],
+                    model_name,
+                    detector_backend,
+                    face_confidence_threshold
+                )
+                self.DB.upload_embedding_to_database(
+                    embedding_outputs,
+                    collection_name,
+                )
+
+                total_files_uploaded += len(img_paths[end_idx:])
                 log_info(
                     "Successfully uploaded "
                     + str(total_files_uploaded)
@@ -105,7 +104,7 @@ class FaceMatchModel:
                 + collection_name
             )
         except Exception as e:
-            return f"An error occurred: {str(e)}"
+            return f"Bulk Upload Error: {str(e)}"
 
     # Function that takes in path to image and returns all images that have the same person.
     def find_face(self, image_file_path, threshold=None, collection_name=None):
@@ -137,21 +136,6 @@ class FaceMatchModel:
                         n_results=10,
                         threshold=threshold,
                     )
-                    # for embedding_output in embedding_outputs:
-                    # if toggle_faiss:
-                    #     # Use Faiss
-                    #     output = cosine_similarity_search_faiss(
-                    #         embedding_output["embedding"],
-                    #         database_path,
-                    #         threshold=threshold,
-                    #     )
-                    # else:
-                    #     # Use linear similarity search
-                    #     output = cosine_similarity_search(
-                    #         embedding_output["embedding"],
-                    #         database_path,
-                    #         threshold=threshold,
-                    #     )
                     matching_image_paths.extend(output)
                     return True, matching_image_paths
                 else:
@@ -182,46 +166,47 @@ class FaceMatchModel:
             if threshold is None:
                 threshold = config["cosine-threshold"]
             # Call face_recognition function and perform similarity check to find identical persons.
-            all_embedding_outputs = []
             all_matching_image_paths = []
 
             img_files = os.listdir(query_directory)
             img_files.sort()
-            for idx, filename in enumerate(img_files):
-                file_path = os.path.join(query_directory, filename)
-                log_info(f"Processing file: {file_path}")
+            img_paths = []
+            for filename in img_files:
                 if filename.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp")):
-                    status, embedding_outputs = detect_faces_and_get_embeddings(
-                        file_path,
-                        model_name,
-                        detector_backend,
-                        face_confidence_threshold,
-                    )
-                    if status:
-                        all_embedding_outputs.append(embedding_outputs)
-                    else:
-                        all_embedding_outputs.append([])
+                    img_paths.append(os.path.join(query_directory, filename))
 
-                num_embeddings = len(all_embedding_outputs)
+            end_idx = 0
 
-                if num_embeddings % query_batch_size == 0 and num_embeddings != 0:
-                    matching_image_paths = self.DBquery_bulk(
+            for batch in range(len(img_paths) // query_batch_size):
+                start_idx = batch * query_batch_size
+                end_idx = start_idx + query_batch_size
+                status, embedding_outputs = detect_faces_and_get_embeddings(
+                    img_paths[start_idx:end_idx],
+                    model_name,
+                    detector_backend,
+                    face_confidence_threshold
+                )
+
+                matching_image_paths = self.DB.query_bulk(
                         collection_name,
-                        all_embedding_outputs,
+                        embedding_outputs,
                         10,
                         threshold,
                         similarity_filter,
-                    )
-                    all_embedding_outputs = []
-                    all_matching_image_paths.extend(matching_image_paths)
-                    log_info(
-                        f"Query: {img_files[idx - num_embeddings+1]}  Match: {matching_image_paths[0]}"
-                    )
+                )
+                all_matching_image_paths.extend(matching_image_paths)
+            
+            if (len(img_paths) % query_batch_size) != 0:
+                status, embedding_outputs = detect_faces_and_get_embeddings(
+                    img_paths[end_idx:],
+                    model_name,
+                    detector_backend,
+                    face_confidence_threshold
+                )
 
-            if len(all_embedding_outputs) != 0:
                 matching_image_paths = self.DB.query_bulk(
                     collection_name,
-                    all_embedding_outputs,
+                    embedding_outputs,
                     10,
                     threshold,
                     similarity_filter,

--- a/src/face-detection-recognition/face_detection_recognition/interface.py
+++ b/src/face-detection-recognition/face_detection_recognition/interface.py
@@ -40,7 +40,9 @@ class FaceMatchModel:
             for root, dirs, files in os.walk(image_directory_path):
                 files.sort()
                 for filename in files:
-                    if filename.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp")):
+                    if filename.lower().endswith(
+                        (".png", ".jpg", ".jpeg", ".gif", ".bmp")
+                    ):
                         img_paths.append(os.path.join(image_directory_path, filename))
 
             end_idx = 0
@@ -56,14 +58,14 @@ class FaceMatchModel:
                     model_name,
                     detector_backend,
                     face_confidence_threshold,
-                    separate_detections=False
+                    separate_detections=False,
                 )
 
                 total_files_uploaded += upload_batch_size
 
                 self.DB.upload_embedding_to_database(
-                        embedding_outputs,
-                        collection_name,
+                    embedding_outputs,
+                    collection_name,
                 )
 
                 log_info(
@@ -80,7 +82,7 @@ class FaceMatchModel:
                     model_name,
                     detector_backend,
                     face_confidence_threshold,
-                    separate_detections=False
+                    separate_detections=False,
                 )
                 self.DB.upload_embedding_to_database(
                     embedding_outputs,
@@ -128,7 +130,7 @@ class FaceMatchModel:
                     model_name,
                     detector_backend,
                     face_confidence_threshold,
-                    separate_detections=False
+                    separate_detections=False,
                 )
                 matching_image_paths = []
                 # If image has a valid face, perform similarity check
@@ -188,27 +190,27 @@ class FaceMatchModel:
                     model_name,
                     detector_backend,
                     face_confidence_threshold,
-                    separate_detections=True
+                    separate_detections=True,
                 )
 
                 matching_image_paths = self.DB.query_bulk(
-                        collection_name,
-                        embedding_outputs,
-                        10,
-                        threshold,
-                        similarity_filter,
+                    collection_name,
+                    embedding_outputs,
+                    10,
+                    threshold,
+                    similarity_filter,
                 )
                 all_matching_image_paths.extend(matching_image_paths)
-            
+
             if (len(img_paths) % query_batch_size) != 0:
                 status, embedding_outputs = detect_faces_and_get_embeddings(
                     img_paths[end_idx:],
                     model_name,
                     detector_backend,
                     face_confidence_threshold,
-                    separate_detections=True
+                    separate_detections=True,
                 )
-                
+
                 matching_image_paths = self.DB.query_bulk(
                     collection_name,
                     embedding_outputs,

--- a/src/face-detection-recognition/face_detection_recognition/interface.py
+++ b/src/face-detection-recognition/face_detection_recognition/interface.py
@@ -51,7 +51,7 @@ class FaceMatchModel:
             total_files_uploaded = 0
 
             for batch in range(len(img_paths) // upload_batch_size):
-                start_idx = batch * upload_batch_size
+                start_idx = end_idx
                 end_idx = start_idx + upload_batch_size
                 status, embedding_outputs = detect_faces_and_get_embeddings(
                     img_paths[start_idx:end_idx],
@@ -183,7 +183,7 @@ class FaceMatchModel:
             end_idx = 0
 
             for batch in range(len(img_paths) // query_batch_size):
-                start_idx = batch * query_batch_size
+                start_idx = end_idx
                 end_idx = start_idx + query_batch_size
                 status, embedding_outputs = detect_faces_and_get_embeddings(
                     img_paths[start_idx:end_idx],

--- a/src/face-detection-recognition/face_detection_recognition/interface.py
+++ b/src/face-detection-recognition/face_detection_recognition/interface.py
@@ -55,7 +55,8 @@ class FaceMatchModel:
                     img_paths[start_idx:end_idx],
                     model_name,
                     detector_backend,
-                    face_confidence_threshold
+                    face_confidence_threshold,
+                    separate_detections=False
                 )
 
                 total_files_uploaded += upload_batch_size
@@ -78,7 +79,8 @@ class FaceMatchModel:
                     img_paths[end_idx:],
                     model_name,
                     detector_backend,
-                    face_confidence_threshold
+                    face_confidence_threshold,
+                    separate_detections=False
                 )
                 self.DB.upload_embedding_to_database(
                     embedding_outputs,
@@ -126,6 +128,7 @@ class FaceMatchModel:
                     model_name,
                     detector_backend,
                     face_confidence_threshold,
+                    separate_detections=False
                 )
                 matching_image_paths = []
                 # If image has a valid face, perform similarity check
@@ -184,7 +187,8 @@ class FaceMatchModel:
                     img_paths[start_idx:end_idx],
                     model_name,
                     detector_backend,
-                    face_confidence_threshold
+                    face_confidence_threshold,
+                    separate_detections=True
                 )
 
                 matching_image_paths = self.DB.query_bulk(
@@ -201,9 +205,10 @@ class FaceMatchModel:
                     img_paths[end_idx:],
                     model_name,
                     detector_backend,
-                    face_confidence_threshold
+                    face_confidence_threshold,
+                    separate_detections=True
                 )
-
+                
                 matching_image_paths = self.DB.query_bulk(
                     collection_name,
                     embedding_outputs,

--- a/src/face-detection-recognition/face_detection_recognition/utils/retinaface_utils.py
+++ b/src/face-detection-recognition/face_detection_recognition/utils/retinaface_utils.py
@@ -654,7 +654,7 @@ def process_retinaface_detections_for_facenet512(
     all_boxes,
     all_scores,
     all_landmarks,
-    separate_detections, # boolean whether or not to separate detections per img in output
+    separate_detections,  # boolean whether or not to separate detections per img in output
 ):
 
     face_embeddings = []
@@ -663,7 +663,9 @@ def process_retinaface_detections_for_facenet512(
     regions = []
 
     detections_per_image = []
-    for boxes, scores, landmarks, image_path, img in zip(all_boxes, all_scores, all_landmarks, image_paths, imgs):
+    for boxes, scores, landmarks, image_path, img in zip(
+        all_boxes, all_scores, all_landmarks, image_paths, imgs
+    ):
         detections_per_image.append(len(boxes))
         for i, (box, score, landmark) in enumerate(zip(boxes, scores, landmarks)):
             try:
@@ -743,7 +745,9 @@ def process_retinaface_detections_for_facenet512(
                         debug_dir, f"{os.path.basename(image_path)}_face_{i}.jpg"
                     )
                     if isinstance(detection, np.ndarray):
-                        cv2.imwrite(face_path, cv2.cvtColor(detection, cv2.COLOR_RGB2BGR))
+                        cv2.imwrite(
+                            face_path, cv2.cvtColor(detection, cv2.COLOR_RGB2BGR)
+                        )
 
                 detections.append(detection)
                 path_strs.append(image_path)
@@ -760,18 +764,18 @@ def process_retinaface_detections_for_facenet512(
 
     except Exception as e:
         logger.error(f"Error getting embedding for face {i}: {str(e)}")
-    
+
     i = 0
     for num_detections in detections_per_image:
         cur_img_face_embeddings = []
         for _ in range(num_detections):
             if embeddings[i] is not None:
                 bbox = [
-                                regions[i]["x"],
-                                regions[i]["y"],
-                                regions[i]["w"],
-                                regions[i]["h"],
-                            ]
+                    regions[i]["x"],
+                    regions[i]["y"],
+                    regions[i]["w"],
+                    regions[i]["h"],
+                ]
                 image = sha256_image(path_strs[i], bbox)
                 cur_img_face_embeddings.append(
                     {
@@ -912,7 +916,7 @@ def process_retinaface_detections_for_arcface(
     all_boxes,
     all_scores,
     all_landmarks,
-    separate_detections, # boolean whether or not to separate detections per img in output
+    separate_detections,  # boolean whether or not to separate detections per img in output
 ):
 
     face_embeddings = []
@@ -920,7 +924,9 @@ def process_retinaface_detections_for_arcface(
     path_strs = []
     regions = []
     detections_per_image = []
-    for boxes, scores, landmarks, image_path, img in zip(all_boxes, all_scores, all_landmarks, image_paths, imgs):
+    for boxes, scores, landmarks, image_path, img in zip(
+        all_boxes, all_scores, all_landmarks, image_paths, imgs
+    ):
         detections_per_image.append(len(boxes))
         for i, (box, score, landmark) in enumerate(zip(boxes, scores, landmarks)):
             try:
@@ -1010,7 +1016,9 @@ def process_retinaface_detections_for_arcface(
                         debug_dir, f"{os.path.basename(image_path)}_face_{i}.jpg"
                     )
                     if isinstance(detection, np.ndarray):
-                        cv2.imwrite(face_path, cv2.cvtColor(detection, cv2.COLOR_RGB2BGR))
+                        cv2.imwrite(
+                            face_path, cv2.cvtColor(detection, cv2.COLOR_RGB2BGR)
+                        )
 
                 detections.append(detection)
                 path_strs.append(image_path)
@@ -1034,11 +1042,11 @@ def process_retinaface_detections_for_arcface(
         for _ in range(num_detections):
             if embeddings[i] is not None:
                 bbox = [
-                                regions[i]["x"],
-                                regions[i]["y"],
-                                regions[i]["w"],
-                                regions[i]["h"],
-                            ]
+                    regions[i]["x"],
+                    regions[i]["y"],
+                    regions[i]["w"],
+                    regions[i]["h"],
+                ]
                 image = sha256_image(path_strs[i], bbox)
                 cur_img_face_embeddings.append(
                     {
@@ -1051,7 +1059,7 @@ def process_retinaface_detections_for_arcface(
                     }
                 )
             i += 1
-            
+
         if separate_detections:
             face_embeddings.append(cur_img_face_embeddings)
         else:

--- a/src/face-detection-recognition/face_detection_recognition/utils/retinaface_utils.py
+++ b/src/face-detection-recognition/face_detection_recognition/utils/retinaface_utils.py
@@ -654,6 +654,7 @@ def process_retinaface_detections_for_facenet512(
     all_boxes,
     all_scores,
     all_landmarks,
+    separate_detections, # boolean whether or not to separate detections per img in output
 ):
 
     face_embeddings = []
@@ -661,7 +662,9 @@ def process_retinaface_detections_for_facenet512(
     path_strs = []
     regions = []
 
+    detections_per_image = []
     for boxes, scores, landmarks, image_path, img in zip(all_boxes, all_scores, all_landmarks, image_paths, imgs):
+        detections_per_image.append(len(boxes))
         for i, (box, score, landmark) in enumerate(zip(boxes, scores, landmarks)):
             try:
                 # Get initial box coordinates
@@ -758,26 +761,34 @@ def process_retinaface_detections_for_facenet512(
     except Exception as e:
         logger.error(f"Error getting embedding for face {i}: {str(e)}")
     
-    
-    for i in range(len(embeddings)):
-        if embeddings[i] is not None:
-            bbox = [
-                            regions[i]["x"],
-                            regions[i]["y"],
-                            regions[i]["w"],
-                            regions[i]["h"],
-                        ]
-            image = sha256_image(path_strs[i], bbox)
-            face_embeddings.append(
-                {
-                    "image_path": path_strs[i],
-                    "embedding": embeddings[i],
-                    "bbox": bbox,
-                    "confidence": regions[i]["confidence"],
-                    "sha256_image": image,
-                    "model_name": model_name,
-                }
-            )
+    i = 0
+    for num_detections in detections_per_image:
+        cur_img_face_embeddings = []
+        for _ in range(num_detections):
+            if embeddings[i] is not None:
+                bbox = [
+                                regions[i]["x"],
+                                regions[i]["y"],
+                                regions[i]["w"],
+                                regions[i]["h"],
+                            ]
+                image = sha256_image(path_strs[i], bbox)
+                cur_img_face_embeddings.append(
+                    {
+                        "image_path": path_strs[i],
+                        "embedding": embeddings[i],
+                        "bbox": bbox,
+                        "confidence": regions[i]["confidence"],
+                        "sha256_image": image,
+                        "model_name": model_name,
+                    }
+                )
+            i += 1
+
+        if separate_detections:
+            face_embeddings.append(cur_img_face_embeddings)
+        else:
+            face_embeddings.extend(cur_img_face_embeddings)
 
     return face_embeddings
 
@@ -901,13 +912,16 @@ def process_retinaface_detections_for_arcface(
     all_boxes,
     all_scores,
     all_landmarks,
+    separate_detections, # boolean whether or not to separate detections per img in output
 ):
 
     face_embeddings = []
     detections = []
     path_strs = []
     regions = []
+    detections_per_image = []
     for boxes, scores, landmarks, image_path, img in zip(all_boxes, all_scores, all_landmarks, image_paths, imgs):
+        detections_per_image.append(len(boxes))
         for i, (box, score, landmark) in enumerate(zip(boxes, scores, landmarks)):
             try:
                 # Determine bounding box - use landmarks if available for better box
@@ -1014,24 +1028,33 @@ def process_retinaface_detections_for_arcface(
     except Exception as e:
         logger.error(f"Error getting embedding for face {i}: {str(e)}")
 
-    for i in range(len(embeddings)):
-        if embeddings[i] is not None:
-            bbox = [
-                            regions[i]["x"],
-                            regions[i]["y"],
-                            regions[i]["w"],
-                            regions[i]["h"],
-                        ]
-            image = sha256_image(path_strs[i], bbox)
-            face_embeddings.append(
-                {
-                    "image_path": path_strs[i],
-                    "embedding": embeddings[i],
-                    "bbox": bbox,
-                    "confidence": regions[i]["confidence"],
-                    "sha256_image": image,
-                    "model_name": model_name,
-                }
-            )
+    i = 0
+    for num_detections in detections_per_image:
+        cur_img_face_embeddings = []
+        for _ in range(num_detections):
+            if embeddings[i] is not None:
+                bbox = [
+                                regions[i]["x"],
+                                regions[i]["y"],
+                                regions[i]["w"],
+                                regions[i]["h"],
+                            ]
+                image = sha256_image(path_strs[i], bbox)
+                cur_img_face_embeddings.append(
+                    {
+                        "image_path": path_strs[i],
+                        "embedding": embeddings[i],
+                        "bbox": bbox,
+                        "confidence": regions[i]["confidence"],
+                        "sha256_image": image,
+                        "model_name": model_name,
+                    }
+                )
+            i += 1
+            
+        if separate_detections:
+            face_embeddings.append(cur_img_face_embeddings)
+        else:
+            face_embeddings.extend(cur_img_face_embeddings)
 
     return face_embeddings

--- a/src/face-detection-recognition/face_detection_recognition/utils/retinaface_utils.py
+++ b/src/face-detection-recognition/face_detection_recognition/utils/retinaface_utils.py
@@ -5,6 +5,7 @@ import os
 import onnxruntime as ort
 
 from face_detection_recognition.utils.get_batch_embeddings import get_embedding
+from face_detection_recognition.hash import sha256_image
 
 
 logger = logging.getLogger(__name__)
@@ -644,18 +645,15 @@ def crop_face_for_facenet512(face_img):
 
 
 def process_retinaface_detections_for_facenet512(
-    img,
+    imgs,
     align,
     target_size,
-    normalization,
     visualize,
-    image_path,
+    image_paths,
     model_name,
-    model_onnx_path,
-    path_str,
-    boxes,
-    scores,
-    landmarks,
+    all_boxes,
+    all_scores,
+    all_landmarks,
 ):
 
     face_embeddings = []
@@ -663,93 +661,94 @@ def process_retinaface_detections_for_facenet512(
     path_strs = []
     regions = []
 
-    for i, (box, score, landmark) in enumerate(zip(boxes, scores, landmarks)):
-        try:
-            # Get initial box coordinates
-            x1, y1, x2, y2 = map(int, box)
+    for boxes, scores, landmarks, image_path, img in zip(all_boxes, all_scores, all_landmarks, image_paths, imgs):
+        for i, (box, score, landmark) in enumerate(zip(boxes, scores, landmarks)):
+            try:
+                # Get initial box coordinates
+                x1, y1, x2, y2 = map(int, box)
 
-            # Calculate the center of the face
-            center_x = (x1 + x2) // 2
-            center_y = (y1 + y2) // 2
+                # Calculate the center of the face
+                center_x = (x1 + x2) // 2
+                center_y = (y1 + y2) // 2
 
-            height = y2 - y1
-            width = x2 - x1
+                height = y2 - y1
+                width = x2 - x1
 
-            # take the larger dimension (and add 10% padding)
-            side_length = int(max(height, width) * 1.1)
+                # take the larger dimension (and add 10% padding)
+                side_length = int(max(height, width) * 1.1)
 
-            # new coordinates based on center
-            new_x1 = center_x - side_length // 2
-            new_y1 = center_y - side_length // 2
-            new_x2 = center_x + side_length // 2
-            new_y2 = center_y + side_length // 2
+                # new coordinates based on center
+                new_x1 = center_x - side_length // 2
+                new_y1 = center_y - side_length // 2
+                new_x2 = center_x + side_length // 2
+                new_y2 = center_y + side_length // 2
 
-            new_x1 = max(0, new_x1)
-            new_y1 = max(0, new_y1)
-            new_x2 = min(img.shape[1], new_x2)
-            new_y2 = min(img.shape[0], new_y2)
+                new_x1 = max(0, new_x1)
+                new_y1 = max(0, new_y1)
+                new_x2 = min(img.shape[1], new_x2)
+                new_y2 = min(img.shape[0], new_y2)
 
-            x1, y1, x2, y2 = new_x1, new_y1, new_x2, new_y2
+                x1, y1, x2, y2 = new_x1, new_y1, new_x2, new_y2
 
-            if x2 <= x1 or y2 <= y1:
+                if x2 <= x1 or y2 <= y1:
+                    continue
+
+                face = img[y1:y2, x1:x2].copy()
+
+                region = {
+                    "x": x1,
+                    "y": y1,
+                    "w": x2 - x1,
+                    "h": y2 - y1,
+                    "confidence": float(score),
+                }
+
+                # Add eye landmarks if available
+                if landmark and len(landmark) >= 2:
+                    region["left_eye"] = tuple(map(int, landmark[0]))
+                    region["right_eye"] = tuple(map(int, landmark[1]))
+                else:
+                    region["left_eye"] = None
+                    region["right_eye"] = None
+
+                # Simple alignment if landmarks available
+                if (
+                    align
+                    and region["left_eye"] is not None
+                    and region["right_eye"] is not None
+                ):
+                    aligned_face = simple_align_face(face, region)
+                    if aligned_face is not None and aligned_face.size > 0:
+                        face = aligned_face
+
+                # resize directly to target size
+                if face.shape[0] > 0 and face.shape[1] > 0:
+                    face_resized = cv2.resize(face, target_size)
+                else:
+                    continue
+
+                face_normalized = face_resized.astype(np.float32)
+                face_normalized = (face_normalized - 127.5) / 128.0
+
+                # prepare for embedding
+                detection = ((face_normalized * 128.0) + 127.5).astype(np.uint8)
+
+                if visualize and isinstance(image_path, str):
+                    debug_dir = "debug_faces"
+                    os.makedirs(debug_dir, exist_ok=True)
+                    face_path = os.path.join(
+                        debug_dir, f"{os.path.basename(image_path)}_face_{i}.jpg"
+                    )
+                    if isinstance(detection, np.ndarray):
+                        cv2.imwrite(face_path, cv2.cvtColor(detection, cv2.COLOR_RGB2BGR))
+
+                detections.append(detection)
+                path_strs.append(image_path)
+                regions.append(region)
+
+            except Exception as e:
+                logger.error(f"Error processing face {i}: {str(e)}")
                 continue
-
-            face = img[y1:y2, x1:x2].copy()
-
-            region = {
-                "x": x1,
-                "y": y1,
-                "w": x2 - x1,
-                "h": y2 - y1,
-                "confidence": float(score),
-            }
-
-            # Add eye landmarks if available
-            if landmark and len(landmark) >= 2:
-                region["left_eye"] = tuple(map(int, landmark[0]))
-                region["right_eye"] = tuple(map(int, landmark[1]))
-            else:
-                region["left_eye"] = None
-                region["right_eye"] = None
-
-            # Simple alignment if landmarks available
-            if (
-                align
-                and region["left_eye"] is not None
-                and region["right_eye"] is not None
-            ):
-                aligned_face = simple_align_face(face, region)
-                if aligned_face is not None and aligned_face.size > 0:
-                    face = aligned_face
-
-            # resize directly to target size
-            if face.shape[0] > 0 and face.shape[1] > 0:
-                face_resized = cv2.resize(face, target_size)
-            else:
-                continue
-
-            face_normalized = face_resized.astype(np.float32)
-            face_normalized = (face_normalized - 127.5) / 128.0
-
-            # prepare for embedding
-            detection = ((face_normalized * 128.0) + 127.5).astype(np.uint8)
-
-            if visualize and isinstance(image_path, str):
-                debug_dir = "debug_faces"
-                os.makedirs(debug_dir, exist_ok=True)
-                face_path = os.path.join(
-                    debug_dir, f"{os.path.basename(image_path)}_face_{i}.jpg"
-                )
-                if isinstance(detection, np.ndarray):
-                    cv2.imwrite(face_path, cv2.cvtColor(detection, cv2.COLOR_RGB2BGR))
-
-            detections.append(detection)
-            path_strs.append(path_str)
-            regions.append(region)
-
-        except Exception as e:
-            logger.error(f"Error processing face {i}: {str(e)}")
-            continue
 
     # Generate embedding
     try:
@@ -758,21 +757,25 @@ def process_retinaface_detections_for_facenet512(
 
     except Exception as e:
         logger.error(f"Error getting embedding for face {i}: {str(e)}")
-
+    
+    
     for i in range(len(embeddings)):
         if embeddings[i] is not None:
-
+            bbox = [
+                            regions[i]["x"],
+                            regions[i]["y"],
+                            regions[i]["w"],
+                            regions[i]["h"],
+                        ]
+            image = sha256_image(path_strs[i], bbox)
             face_embeddings.append(
                 {
-                    "image_path": path_str,
+                    "image_path": path_strs[i],
                     "embedding": embeddings[i],
-                    "bbox": [
-                        regions[i]["x"],
-                        regions[i]["y"],
-                        regions[i]["w"],
-                        regions[i]["h"],
-                    ],
+                    "bbox": bbox,
                     "confidence": regions[i]["confidence"],
+                    "sha256_image": image,
+                    "model_name": model_name,
                 }
             )
 
@@ -888,122 +891,120 @@ def crop_face_for_arcface(face_img):
 
 
 def process_retinaface_detections_for_arcface(
-    img,
+    imgs,
     align,
     target_size,
     normalization,
     visualize,
-    image_path,
+    image_paths,
     model_name,
-    model_onnx_path,
-    path_str,
-    boxes,
-    scores,
-    landmarks,
+    all_boxes,
+    all_scores,
+    all_landmarks,
 ):
 
     face_embeddings = []
     detections = []
     path_strs = []
     regions = []
-
-    for i, (box, score, landmark) in enumerate(zip(boxes, scores, landmarks)):
-        try:
-            # Determine bounding box - use landmarks if available for better box
-            if landmark and len(landmark) >= 5:
-                # Use a larger scale factor for ArcFace to include more context
-                scale_factor = 3.0
-                improved_box = create_square_bounds_from_landmarks(
-                    landmark, img.shape, scale_factor=scale_factor
-                )
-                if improved_box:
-                    x1, y1, x2, y2 = improved_box
+    for boxes, scores, landmarks, image_path, img in zip(all_boxes, all_scores, all_landmarks, image_paths, imgs):
+        for i, (box, score, landmark) in enumerate(zip(boxes, scores, landmarks)):
+            try:
+                # Determine bounding box - use landmarks if available for better box
+                if landmark and len(landmark) >= 5:
+                    # Use a larger scale factor for ArcFace to include more context
+                    scale_factor = 3.0
+                    improved_box = create_square_bounds_from_landmarks(
+                        landmark, img.shape, scale_factor=scale_factor
+                    )
+                    if improved_box:
+                        x1, y1, x2, y2 = improved_box
+                    else:
+                        x1, y1, x2, y2 = map(int, box)
                 else:
+                    # If no landmarks, use the original box but ensure it's square
                     x1, y1, x2, y2 = map(int, box)
-            else:
-                # If no landmarks, use the original box but ensure it's square
-                x1, y1, x2, y2 = map(int, box)
-                width = x2 - x1
-                height = y2 - y1
+                    width = x2 - x1
+                    height = y2 - y1
 
-                if width < height:
-                    # expand width
-                    center_x = (x1 + x2) // 2
-                    half_height = height // 2
-                    x1 = center_x - half_height
-                    x2 = center_x + half_height
-                elif height < width:
-                    # expand height
-                    center_y = (y1 + y2) // 2
-                    half_width = width // 2
-                    y1 = center_y - half_width
-                    y2 = center_y + half_width
+                    if width < height:
+                        # expand width
+                        center_x = (x1 + x2) // 2
+                        half_height = height // 2
+                        x1 = center_x - half_height
+                        x2 = center_x + half_height
+                    elif height < width:
+                        # expand height
+                        center_y = (y1 + y2) // 2
+                        half_width = width // 2
+                        y1 = center_y - half_width
+                        y2 = center_y + half_width
 
-            x1 = max(0, x1)
-            y1 = max(0, y1)
-            x2 = min(img.shape[1], x2)
-            y2 = min(img.shape[0], y2)
+                x1 = max(0, x1)
+                y1 = max(0, y1)
+                x2 = min(img.shape[1], x2)
+                y2 = min(img.shape[0], y2)
 
-            if x2 <= x1 or y2 <= y1:
-                continue
+                if x2 <= x1 or y2 <= y1:
+                    continue
 
-            face = img[y1:y2, x1:x2].copy()
+                face = img[y1:y2, x1:x2].copy()
 
-            region = {
-                "x": x1,
-                "y": y1,
-                "w": x2 - x1,
-                "h": y2 - y1,
-                "confidence": float(score),
-            }
+                region = {
+                    "x": x1,
+                    "y": y1,
+                    "w": x2 - x1,
+                    "h": y2 - y1,
+                    "confidence": float(score),
+                }
 
-            # Set landmarks for alignment
-            if landmark and len(landmark) >= 2:
-                region["left_eye"] = tuple(map(int, landmark[0]))
-                region["right_eye"] = tuple(map(int, landmark[1]))
-            else:
-                region["left_eye"] = None
-                region["right_eye"] = None
+                # Set landmarks for alignment
+                if landmark and len(landmark) >= 2:
+                    region["left_eye"] = tuple(map(int, landmark[0]))
+                    region["right_eye"] = tuple(map(int, landmark[1]))
+                else:
+                    region["left_eye"] = None
+                    region["right_eye"] = None
 
-            if (
-                align
-                and region["left_eye"] is not None
-                and region["right_eye"] is not None
-            ):
-                aligned_face = optimize_arcface_alignment(face, img, region)
-                if aligned_face is not None and aligned_face.size > 0:
-                    face = aligned_face
+                if (
+                    align
+                    and region["left_eye"] is not None
+                    and region["right_eye"] is not None
+                ):
+                    aligned_face = optimize_arcface_alignment(face, img, region)
+                    if aligned_face is not None and aligned_face.size > 0:
+                        face = aligned_face
 
-            face = crop_face_for_arcface(face)
+                face = crop_face_for_arcface(face)
 
-            face_normalized = normalize_face(
-                face, target_size, model_name, normalization
-            )
-            if face_normalized is None:
-                continue
-
-            detection = prepare_for_embedding(
-                face_normalized, model_name, normalization
-            )
-            if detection is None:
-                continue
-
-            if visualize and isinstance(image_path, str):
-                debug_dir = "debug_faces"
-                os.makedirs(debug_dir, exist_ok=True)
-                face_path = os.path.join(
-                    debug_dir, f"{os.path.basename(image_path)}_face_{i}.jpg"
+                face_normalized = normalize_face(
+                    face, target_size, model_name, normalization
                 )
-                if isinstance(detection, np.ndarray):
-                    cv2.imwrite(face_path, cv2.cvtColor(detection, cv2.COLOR_RGB2BGR))
+                if face_normalized is None:
+                    continue
 
-            detections.append(detection)
-            path_strs.append(path_str)
-            regions.append(region)
+                detection = prepare_for_embedding(
+                    face_normalized, model_name, normalization
+                )
+                if detection is None:
+                    continue
 
-        except Exception as e:
-            logger.error(f"Error processing face {i}: {str(e)}")
-            continue
+                if visualize and isinstance(image_path, str):
+                    debug_dir = "debug_faces"
+                    os.makedirs(debug_dir, exist_ok=True)
+                    face_path = os.path.join(
+                        debug_dir, f"{os.path.basename(image_path)}_face_{i}.jpg"
+                    )
+                    if isinstance(detection, np.ndarray):
+                        cv2.imwrite(face_path, cv2.cvtColor(detection, cv2.COLOR_RGB2BGR))
+
+                detections.append(detection)
+                path_strs.append(image_path)
+                regions.append(region)
+
+            except Exception as e:
+                logger.error(f"Error processing face {i}: {str(e)}")
+                continue
 
     # Generate embedding
     try:
@@ -1015,18 +1016,21 @@ def process_retinaface_detections_for_arcface(
 
     for i in range(len(embeddings)):
         if embeddings[i] is not None:
-
+            bbox = [
+                            regions[i]["x"],
+                            regions[i]["y"],
+                            regions[i]["w"],
+                            regions[i]["h"],
+                        ]
+            image = sha256_image(path_strs[i], bbox)
             face_embeddings.append(
                 {
-                    "image_path": path_str,
+                    "image_path": path_strs[i],
                     "embedding": embeddings[i],
-                    "bbox": [
-                        regions[i]["x"],
-                        regions[i]["y"],
-                        regions[i]["w"],
-                        regions[i]["h"],
-                    ],
+                    "bbox": bbox,
                     "confidence": regions[i]["confidence"],
+                    "sha256_image": image,
+                    "model_name": model_name,
                 }
             )
 

--- a/src/face-detection-recognition/face_detection_recognition/utils/yolo_utils.py
+++ b/src/face-detection-recognition/face_detection_recognition/utils/yolo_utils.py
@@ -471,6 +471,7 @@ def process_yolo_detections(
     model_name="ArcFace",
     face_confidence_threshold=0.02,
     detector_backend="yolov8",
+    separate_detections=False
 ):
     """Process YOLO face detections and generate embeddings."""
     face_embeddings = []
@@ -478,7 +479,11 @@ def process_yolo_detections(
     path_strs = []
     regions = []
 
+    detections_per_image = []
     for boxes, scores, landmarks, image_path, img in zip(all_boxes, all_scores, all_landmarks, image_paths, imgs):
+
+        detections_per_image.append(len(boxes))
+
         if len(boxes) == 0:
             continue
 
@@ -545,24 +550,34 @@ def process_yolo_detections(
     except Exception as e:
         logger.error(f"Error getting embedding for face {i}: {str(e)}")
 
-    for i in range(len(embeddings)):
-        if embeddings[i] is not None:
-            bbox = [
-                        regions[i]["x"],
-                        regions[i]["y"],
-                        regions[i]["w"],
-                        regions[i]["h"],
-                    ]
-            image = sha256_image(image_paths[i], bbox)
-            face_embeddings.append(
-                {
-                    "image_path": image_paths[i],
-                    "embedding": embeddings[i],
-                    "bbox": bbox,
-                    "confidence": regions[i]["confidence"],
-                    "model_name": model_name,
-                    "sha256_image": image
-                }
-            )
+    i = 0
+    for num_detections in detections_per_image:
+        cur_img_face_embeddings = []
+        for _ in range(num_detections):
+            if embeddings[i] is not None:
+                bbox = [
+                                regions[i]["x"],
+                                regions[i]["y"],
+                                regions[i]["w"],
+                                regions[i]["h"],
+                            ]
+                image = sha256_image(path_strs[i], bbox)
+                cur_img_face_embeddings.append(
+                    {
+                        "image_path": path_strs[i],
+                        "embedding": embeddings[i],
+                        "bbox": bbox,
+                        "confidence": regions[i]["confidence"],
+                        "sha256_image": image,
+                        "model_name": model_name,
+                    }
+                )
+            i += 1
+
+        if separate_detections:
+            face_embeddings.append(cur_img_face_embeddings)
+        else:
+            face_embeddings.extend(cur_img_face_embeddings)
+
 
     return face_embeddings

--- a/src/face-detection-recognition/face_detection_recognition/utils/yolo_utils.py
+++ b/src/face-detection-recognition/face_detection_recognition/utils/yolo_utils.py
@@ -5,6 +5,8 @@ import logging
 import matplotlib.pyplot as plt
 import matplotlib
 
+from face_detection_recognition.hash import sha256_image
+
 matplotlib.use("Agg")
 
 from face_detection_recognition.utils.get_batch_embeddings import get_embedding
@@ -457,18 +459,16 @@ def prepare_for_embedding(face, model_name, normalization):
 
 
 def process_yolo_detections(
-    img,
-    boxes,
-    scores,
-    landmarks,
+    imgs,
+    all_boxes,
+    all_scores,
+    all_landmarks,
     align=True,
     target_size=None,
     normalization=True,
     visualize=False,
-    image_path=None,
+    image_paths=None,
     model_name="ArcFace",
-    model_onnx_path=None,
-    path_str=None,
     face_confidence_threshold=0.02,
     detector_backend="yolov8",
 ):
@@ -478,63 +478,64 @@ def process_yolo_detections(
     path_strs = []
     regions = []
 
-    if len(boxes) == 0:
-        return face_embeddings
-
-    valid_faces = sum(1 for score in scores if score >= face_confidence_threshold)
-    if valid_faces == 0:
-        return face_embeddings
-
-    # Process each detected face
-    for i, (box, score) in enumerate(zip(boxes, scores)):
-        if score < face_confidence_threshold:
+    for boxes, scores, landmarks, image_path, img in zip(all_boxes, all_scores, all_landmarks, image_paths, imgs):
+        if len(boxes) == 0:
             continue
 
-        landmark = landmarks[i] if landmarks and i < len(landmarks) else None
-
-        face, region = extract_face(img, box, landmark, detector_backend)
-
-        if face is None or face.size == 0:
+        valid_faces = sum(1 for score in scores if score >= face_confidence_threshold)
+        if valid_faces == 0:
             continue
 
-        region["confidence"] = float(score)
-
-        # Align face if landmarks available
-        if align and region["left_eye"] is not None and region["right_eye"] is not None:
-            face = align_face(face, img, region)
-
-        if model_name == "Facenet512":
-            face = crop_face_for_facenet_embedding(face)
-            face_normalized = normalize_face(
-                face, target_size, model_name, normalization
-            )
-            if face_normalized is None:
+        # Process each detected face
+        for i, (box, score) in enumerate(zip(boxes, scores)):
+            if score < face_confidence_threshold:
                 continue
 
-            detection = prepare_for_embedding(
-                face_normalized, model_name, normalization
-            )
-            if detection is None:
+            landmark = landmarks[i] if landmarks and i < len(landmarks) else None
+
+            face, region = extract_face(img, box, landmark, detector_backend)
+
+            if face is None or face.size == 0:
                 continue
 
-        elif model_name == "ArcFace":
-            face = crop_face_for_embedding(face)
-            face_resized = cv2.resize(face, target_size)
-            detection = np.clip(face_resized, 0, 255).astype(np.uint8)
+            region["confidence"] = float(score)
 
-        # Visualize processed faces
-        if visualize and isinstance(image_path, str):
-            debug_dir = "debug_faces"
-            os.makedirs(debug_dir, exist_ok=True)
-            face_path = os.path.join(
-                debug_dir, f"{os.path.basename(image_path)}_face_{i}.jpg"
-            )
-            if isinstance(detection, np.ndarray):
-                cv2.imwrite(face_path, cv2.cvtColor(detection, cv2.COLOR_RGB2BGR))
+            # Align face if landmarks available
+            if align and region["left_eye"] is not None and region["right_eye"] is not None:
+                face = align_face(face, img, region)
 
-        detections.append(detection)
-        path_strs.append(path_str)
-        regions.append(region)
+            if model_name == "Facenet512":
+                face = crop_face_for_facenet_embedding(face)
+                face_normalized = normalize_face(
+                    face, target_size, model_name, normalization
+                )
+                if face_normalized is None:
+                    continue
+
+                detection = prepare_for_embedding(
+                    face_normalized, model_name, normalization
+                )
+                if detection is None:
+                    continue
+
+            elif model_name == "ArcFace":
+                face = crop_face_for_embedding(face)
+                face_resized = cv2.resize(face, target_size)
+                detection = np.clip(face_resized, 0, 255).astype(np.uint8)
+
+            # Visualize processed faces
+            if visualize and isinstance(image_path, str):
+                debug_dir = "debug_faces"
+                os.makedirs(debug_dir, exist_ok=True)
+                face_path = os.path.join(
+                    debug_dir, f"{os.path.basename(image_path)}_face_{i}.jpg"
+                )
+                if isinstance(detection, np.ndarray):
+                    cv2.imwrite(face_path, cv2.cvtColor(detection, cv2.COLOR_RGB2BGR))
+
+            detections.append(detection)
+            path_strs.append(image_paths[i])
+            regions.append(region)
 
     # Generate embedding
     try:
@@ -546,18 +547,21 @@ def process_yolo_detections(
 
     for i in range(len(embeddings)):
         if embeddings[i] is not None:
-
-            face_embeddings.append(
-                {
-                    "image_path": path_str,
-                    "embedding": embeddings[i],
-                    "bbox": [
+            bbox = [
                         regions[i]["x"],
                         regions[i]["y"],
                         regions[i]["w"],
                         regions[i]["h"],
-                    ],
+                    ]
+            image = sha256_image(image_paths[i], bbox)
+            face_embeddings.append(
+                {
+                    "image_path": image_paths[i],
+                    "embedding": embeddings[i],
+                    "bbox": bbox,
                     "confidence": regions[i]["confidence"],
+                    "model_name": model_name,
+                    "sha256_image": image
                 }
             )
 

--- a/src/face-detection-recognition/face_detection_recognition/utils/yolo_utils.py
+++ b/src/face-detection-recognition/face_detection_recognition/utils/yolo_utils.py
@@ -545,7 +545,7 @@ def process_yolo_detections(
                     cv2.imwrite(face_path, cv2.cvtColor(detection, cv2.COLOR_RGB2BGR))
 
             detections.append(detection)
-            path_strs.append(image_paths[i])
+            path_strs.append(image_path)
             regions.append(region)
 
     # Generate embedding

--- a/src/face-detection-recognition/face_detection_recognition/utils/yolo_utils.py
+++ b/src/face-detection-recognition/face_detection_recognition/utils/yolo_utils.py
@@ -471,7 +471,7 @@ def process_yolo_detections(
     model_name="ArcFace",
     face_confidence_threshold=0.02,
     detector_backend="yolov8",
-    separate_detections=False
+    separate_detections=False,
 ):
     """Process YOLO face detections and generate embeddings."""
     face_embeddings = []
@@ -480,7 +480,9 @@ def process_yolo_detections(
     regions = []
 
     detections_per_image = []
-    for boxes, scores, landmarks, image_path, img in zip(all_boxes, all_scores, all_landmarks, image_paths, imgs):
+    for boxes, scores, landmarks, image_path, img in zip(
+        all_boxes, all_scores, all_landmarks, image_paths, imgs
+    ):
 
         detections_per_image.append(len(boxes))
 
@@ -506,7 +508,11 @@ def process_yolo_detections(
             region["confidence"] = float(score)
 
             # Align face if landmarks available
-            if align and region["left_eye"] is not None and region["right_eye"] is not None:
+            if (
+                align
+                and region["left_eye"] is not None
+                and region["right_eye"] is not None
+            ):
                 face = align_face(face, img, region)
 
             if model_name == "Facenet512":
@@ -556,11 +562,11 @@ def process_yolo_detections(
         for _ in range(num_detections):
             if embeddings[i] is not None:
                 bbox = [
-                                regions[i]["x"],
-                                regions[i]["y"],
-                                regions[i]["w"],
-                                regions[i]["h"],
-                            ]
+                    regions[i]["x"],
+                    regions[i]["y"],
+                    regions[i]["w"],
+                    regions[i]["h"],
+                ]
                 image = sha256_image(path_strs[i], bbox)
                 cur_img_face_embeddings.append(
                     {
@@ -578,6 +584,5 @@ def process_yolo_detections(
             face_embeddings.append(cur_img_face_embeddings)
         else:
             face_embeddings.extend(cur_img_face_embeddings)
-
 
     return face_embeddings


### PR DESCRIPTION
Parallelizing embedding extraction across images not just faces within an image. 

Face detection (as opposed to embedding extraction) remains sequential as in order to parallelize you must:
- Make all images the same size via padding (which could affect detection models)
- Use some sort of bucket algorithm to sort images by similar dimensions to minimize padding/size altering required.
